### PR TITLE
Update minecraft_autobackup.sh

### DIFF
--- a/minecraft_autobackup.sh
+++ b/minecraft_autobackup.sh
@@ -105,7 +105,7 @@ fi
 # Deletes backups that are 'n' days old
 if [ $LOGIT -eq 1 ]
 then
-   echo "$(date +"%G-%m-%d %H:%M:%S") [LOG] Removing backups older than 3 days."
+   echo "$(date +"%G-%m-%d %H:%M:%S") [LOG] Removing backups older than $OLDBACKUPS days."
 fi
 OLDBACKUP=`find $PWD/$BACKUPDIR -type d -mtime +$OLDBACKUPS | grep -v -x "$PWD/$BACKUPDIR" | xargs rm -rf`
 


### PR DESCRIPTION
incorrect log number for deleting old backups

note: at the current default of 7 days, and 24 backups per day, this uses a very large amount of disk space.  suggest changing default to 1 day, or removing the hours minutes seconds from the STAMP (this will overwrite the backup each hour)